### PR TITLE
message sending retries after timeout if rate limit is reached

### DIFF
--- a/lib/slack/message.rb
+++ b/lib/slack/message.rb
@@ -9,6 +9,8 @@ module FDE
       YELLOW = '#FEEFB3'.freeze
       RED = '#FFBABA'.freeze
 
+      RETRY_LIMIT = 1
+
 
       attr_accessor :username,
         :title,
@@ -16,6 +18,8 @@ module FDE
         :fields,
         :footer,
         :color
+
+      attr_reader :retries
 
       def initialize(title, fields, options = {})
         @title = title
@@ -32,6 +36,8 @@ module FDE
         if options[:footer]
           @footer = options[:footer]
         end
+
+        @retries = 0
       end
 
       def deliver(channel, level: :info)
@@ -69,10 +75,20 @@ module FDE
           FDE::Slack::Notification.config.webhook,
           channel: channel,
           username: @username
-        )
+        ) do
+          http_client FDE::Slack::Util::HTTPClient
+        end
+
         begin 
           notifier.ping message_hash
-        rescue ::Slack::Notifier::APIError
+        rescue FDE::Slack::APIError => api_error
+          # TooManyRequests, Slack Rate Limit
+          if api_error.response.code == "429" && @retries < RETRY_LIMIT
+            timeout = api_error.response.header['Retry-After'].to_i
+            sleep(timeout) if timeout
+            @retries += 1
+            retry
+          end
           raise FDE::Slack::Message::Error
         end
       end

--- a/lib/slack/notification.rb
+++ b/lib/slack/notification.rb
@@ -5,6 +5,7 @@ require "slack/message"
 require "slack/field"
 require "slack/author"
 require "slack/footer"
+require "slack/util/http_client"
 
 module FDE
   module Slack

--- a/lib/slack/util/http_client.rb
+++ b/lib/slack/util/http_client.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+# Custom HTTP Client to auto-retry once when Slack Rate Limit error is encountered.
+# The basis of this code is from https://github.com/stevenosloan/slack-notifier/blob/master/lib/slack-notifier/util/http_client.rb
+# The improved APIError code from https://github.com/stevenosloan/slack-notifier/pull/111
+# And the rate limit retry is custom
+module FDE
+  module Slack
+    class APIError < StandardError
+      attr_reader :response
+
+      def initialize(response)
+        @response = response
+      end
+
+      def message
+        <<-MSG
+The slack API returned an error with HTTP Code #{@response.code}
+Check the "Handling Errors" section on https://api.slack.com/incoming-webhooks for more information
+        MSG
+      end
+    end
+
+    module Util
+      class HTTPClient
+        class << self
+          def post uri, params
+            HTTPClient.new(uri, params).call
+          end
+        end
+
+        attr_reader :uri, :params, :http_options
+
+        def initialize uri, params
+          @uri          = uri
+          @http_options = params.delete(:http_options) || {}
+          @params       = params
+        end
+
+        def call
+          http_obj.request(request_obj).tap do |response|
+            unless response.is_a?(Net::HTTPSuccess)
+              raise FDE::Slack::APIError.new(response)
+            end
+          end
+        end
+
+        private
+
+        def request_obj
+          req = Net::HTTP::Post.new uri.request_uri
+          req.set_form_data params
+
+          req
+        end
+
+        def http_obj
+          http = Net::HTTP.new uri.host, uri.port
+          http.use_ssl = (uri.scheme == "https")
+
+          http_options.each do |opt, val|
+            if http.respond_to? "#{opt}="
+              http.send "#{opt}=", val
+            else
+              warn "Net::HTTP doesn't respond to `#{opt}=`, ignoring that option"
+            end
+          end
+
+          http
+        end
+      end
+    end
+  end
+end

--- a/spec/slack/util/http_client_spec.rb
+++ b/spec/slack/util/http_client_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FDE::Slack::Util::HTTPClient do
+  describe "::post" do
+    it "initializes Util::HTTPClient with the given uri and params then calls" do
+      http_post_double = instance_double("FDE::Slack::Util::HTTPClient")
+
+      expect(described_class)
+        .to receive(:new).with("uri", "params")
+                         .and_return(http_post_double)
+      expect(http_post_double).to receive(:call)
+
+      described_class.post "uri", "params"
+    end
+
+    # http_post is really tested in the integration spec,
+    # where the internals are run through
+  end
+
+  describe "#initialize" do
+    it "allows setting of options for Net::HTTP" do
+      net_http_double = instance_double("Net::HTTP")
+      http_client     = described_class.new URI.parse("http://example.com"),
+                                            http_options: { open_timeout: 5 }
+
+      allow(Net::HTTP).to receive(:new).and_return(net_http_double)
+      allow(net_http_double).to receive(:use_ssl=)
+      allow(net_http_double).to receive(:request).with(anything) do
+        Net::HTTPOK.new("GET", "200", "OK")
+      end
+
+      expect(net_http_double).to receive(:open_timeout=).with(5)
+
+      http_client.call
+    end
+  end
+
+  describe "#call" do
+    context 'when being rate limited' do
+      it 'raises an error when the response is unsuccessful' do
+        net_http_double = instance_double("Net::HTTP")
+        http_client = described_class.new URI.parse("http://example.com"), {}
+        bad_request = Net::HTTPBadRequest.new("GET", "429", "nothing")
+        allow(bad_request).to receive(:body).and_return("")
+        bad_request.header["Retry-After"] = "15"
+
+        allow(Net::HTTP).to receive(:new).and_return(net_http_double)
+        allow(net_http_double).to receive(:use_ssl=)
+        allow(net_http_double).to receive(:request).with(anything) do
+          bad_request
+        end
+
+        expect { http_client.call }.to raise_error(FDE::Slack::APIError,
+                                                 /HTTP Code 429/)
+      end
+    end
+
+    it "raises an error when the response is unsuccessful" do
+      net_http_double = instance_double("Net::HTTP")
+      http_client = described_class.new URI.parse("http://example.com"), {}
+      bad_request = Net::HTTPBadRequest.new("GET", "400", "Bad Request")
+
+      allow(bad_request).to receive(:body).and_return("something_bad")
+      allow(Net::HTTP).to receive(:new).and_return(net_http_double)
+      allow(net_http_double).to receive(:use_ssl=)
+      allow(net_http_double).to receive(:request).with(anything) do
+        bad_request
+      end
+
+      expect { http_client.call }.to raise_error(FDE::Slack::APIError,
+                                                 /HTTP Code 400/)
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.filter_run :focus => true
+  config.filter_run_excluding :ignore => true
+  config.run_all_when_everything_filtered = true
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
@@ -20,6 +24,7 @@ RSpec.configure do |config|
   config.profile_examples = 10
   config.order = :random
   Kernel.srand config.seed
+
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
Handling this requires our custom http_client implementation because we need access to the original HTTP response when handling the error